### PR TITLE
Update GitStatus.java

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -383,6 +383,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                                         }
                                     }
 
+                                    allBuildParameters.clear();
                                     List<ParameterValue> jobParametersValues = getDefaultParametersValues((Job) project);
                                     for (ParameterValue defaultParameterValue : jobParametersValues) {
                                         if (!buildParametersNames.contains(defaultParameterValue.getName())) {


### PR DESCRIPTION
If  more than one job configuration uses same git repository and same branch as git SCM and jobs are triggered using notifyCommit then default parameters from different jobs are appended in one  allBuildParameters listArray. So jobs with parameters with same names not changing  value.